### PR TITLE
Fix input to kbaseBinnedContigs output widget

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # VirSorter release notes
 =========================================
 
+0.1.30
+------
+* Fixes app output / expected input for output widget mismatch.
+* Other undocumented changes.
+
 0.0.0
 -----
 * Module created by kb-sdk init

--- a/ui/narrative/methods/run_VirSorter/spec.json
+++ b/ui/narrative/methods/run_VirSorter/spec.json
@@ -176,6 +176,10 @@
                     "target_property": "binned_contig_obj_ref"
                 },
                 {
+                    "service_method_output_path": [0,"binned_contig_obj_ref"],
+                    "target_property": "objRef"
+                },
+                {
                     "service_method_output_path": [0, "result_directory"],
                     "target_property": "result_directory"
                 }


### PR DESCRIPTION
VirSorter provides the `binned_contig_obj_ref` field to the `kbaseBinnedContigs` output widget, but that widget expects an`objRef` field:
https://github.com/kbase/narrative/blob/develop/kbase-extension/static/kbase/js/widgets/function_output/kbaseBinnedContigs.js#L33-L47

This PR adds the expected field.

Unfortunately I can't test this without deploying it, and I can't deploy it, so I can't test it. Looks nice, though. Inspires confidence.
