### PR TITLE
reinstall reports client

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # VirSorter release notes
 =========================================
 
+0.1.30
+------
+* Reinstall the KBaseReport client in async mode.
+* Other undocumented changes.
+
 0.0.0
 -----
 * Module created by kb-sdk init

--- a/dependencies.json
+++ b/dependencies.json
@@ -12,7 +12,8 @@
   "version_tag" : "release"
 }, {
   "module_name" : "KBaseReport",
-  "type" : "core"
+  "type" : "sdk",
+  "version_tag" : "release"
 }, {
   "module_name" : "MetagenomeUtils",
   "type" : "sdk",

--- a/lib/installed_clients/KBaseReportClient.py
+++ b/lib/installed_clients/KBaseReportClient.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 try:
     # baseclient and this client are in a package
     from .baseclient import BaseClient as _BaseClient  # @UnusedImport
-except:
+except ImportError:
     # no they aren't
     from baseclient import BaseClient as _BaseClient  # @Reimport
 
@@ -23,15 +23,21 @@ class KBaseReport(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
+            service_ver='release',
+            async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
+            async_job_check_max_time_ms=300000):
         if url is None:
             raise ValueError('A url is required')
-        self._service_ver = None
+        self._service_ver = service_ver
         self._client = _BaseClient(
             url, timeout=timeout, user_id=user_id, password=password,
             token=token, ignore_authrc=ignore_authrc,
             trust_all_ssl_certificates=trust_all_ssl_certificates,
-            auth_svc=auth_svc)
+            auth_svc=auth_svc,
+            async_job_check_time_ms=async_job_check_time_ms,
+            async_job_check_time_scale_percent=async_job_check_time_scale_percent,
+            async_job_check_max_time_ms=async_job_check_max_time_ms)
 
     def create(self, params, context=None):
         """
@@ -79,9 +85,8 @@ class KBaseReport(object):
            'workspace_id/object_id/version' * @id ws), parameter "name" of
            String
         """
-        return self._client.call_method(
-            'KBaseReport.create',
-            [params], self._service_ver, context)
+        return self._client.run_job('KBaseReport.create',
+                                    [params], self._service_ver, context)
 
     def create_extended_report(self, params, context=None):
         """
@@ -172,10 +177,9 @@ class KBaseReport(object):
            'workspace_id/object_id/version' * @id ws), parameter "name" of
            String
         """
-        return self._client.call_method(
-            'KBaseReport.create_extended_report',
-            [params], self._service_ver, context)
+        return self._client.run_job('KBaseReport.create_extended_report',
+                                    [params], self._service_ver, context)
 
     def status(self, context=None):
-        return self._client.call_method('KBaseReport.status',
-                                        [], self._service_ver, context)
+        return self._client.run_job('KBaseReport.status',
+                                    [], self._service_ver, context)


### PR DESCRIPTION
Current reports client is contacting the callback server in sync mode. Updating the client to use async mode, which includes a bandaid for the BadStatusLine errors.

I tried to run tests locally, but it looks like they're keyed to a specific workspace I can't access so no dice.
